### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/adhiran21/9455ffa9-6628-4fdf-a1c6-5665d77d036c/5f62f5f9-98f9-447f-afc1-b15dc0e3ef37/_apis/work/boardbadge/33b853eb-1a16-42eb-b3f9-19b1e24600af)](https://dev.azure.com/adhiran21/9455ffa9-6628-4fdf-a1c6-5665d77d036c/_boards/board/t/5f62f5f9-98f9-447f-afc1-b15dc0e3ef37/Microsoft.RequirementCategory)
 # azure-board-integration-repo
 Test repo for testing out Azure Board integration


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/adhiran21/9455ffa9-6628-4fdf-a1c6-5665d77d036c/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.